### PR TITLE
docs: update directory structure in copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,31 +29,23 @@ applyTo: "**"
 
 <!-- NOTEで記した内容を基に、src/main/java/com/example以下のディレクトリをツリーで示す.  
 * 機能ごとのパッケージ分割を行う
-  * 例: src/main/java/com/example/user, src/main/java/com/example/order, src/main/java/com/example/product
+  * 例: src/main/java/com/example/user, src/main/java/com/example/order
   * 監視やログ、セキュリティなどの共通機能は、関心事ごとにパッケージを分割する
 * src/main/java/com/example/manage, src/main/java/com/example/monitoring
 -->
 ```plaintext
-src
-└── main
-    └── java
-        └── com
-            └── example
-                ├── user
-                │   ├── UserController.java
-                │   ├── UserService.java
-                │   ├── User.java
-                │   └── UserRepository.java
-                ├── order
-                │   ├── OrderController.java
-                │   ├── OrderService.java
-                │   ├── Order.java
-                │   └── OrderRepository.java
-                ├── product
-                │   ├── ProductController.java
-                │   ├── ProductService.java
-                │   ├── Product.java
-                │   └── ProductRepository.java
-                └── monitoring
-                    └── MonitoringController.java
+src/main/java/com/
+    └── example
+        ├── user
+        │   ├── UserController.java
+        │   ├── UserService.java
+        │   ├── User.java
+        │   └── UserRepository.java
+        ├── order
+        │   ├── OrderController.java
+        │   ├── OrderService.java
+        │   ├── Order.java
+        │   └── OrderRepository.java
+        └── monitoring
+            └── MonitoringController.java
 ```


### PR DESCRIPTION
This pull request updates the `.github/copilot-instructions.md` file, specifically modifying the directory structure examples to remove the `product` package and simplify the tree representation.

Changes to directory structure examples:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L32-R37): Updated the example directory structure to remove the `product` package, including its associated files (`ProductController.java`, `ProductService.java`, `Product.java`, and `ProductRepository.java`). This reflects a streamlined structure focusing on `user`, `order`, and `monitoring` packages. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L32-R37) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L52-L56)