### PR TITLE
chore: コンテナイメージをビルド・プッシュするワークフロー

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,0 +1,42 @@
+name: Docker Build and Push
+
+on:
+  push:
+    tags:
+      - "*"
+  schedule:
+    - cron: '0 22 * * 0-4'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: my-application
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+      - name: Security scan with Trivy
+        uses: aquasecurity/trivy-action@v0.11.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          exit-code: '0'
+          vuln-types: 'os,library'
+          severity: 'CRITICAL'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building, scanning, and pushing of Docker images to the GitHub Container Registry. The workflow is triggered on tag pushes, scheduled runs, and manual dispatch.

### New Docker automation workflow:

* [`.github/workflows/docker-build-and-push.yml`](diffhunk://#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5R1-R42): Added a workflow named "Docker Build and Push" that includes steps for repository checkout, Docker Buildx setup, authentication with GitHub Container Registry, building and pushing Docker images, and performing security scans using Trivy.