### PR TITLE
Chore/docker build workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-      - name: Security scan with Trivy
+      - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.29.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,0 +1,42 @@
+name: Docker Build and Push
+
+on:
+  push:
+    tags:
+      - "*"
+  schedule:
+    - cron: '0 22 * * 0-4'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: my-application
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      - name: Security scan with Trivy
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          exit-code: '0'
+          vuln-types: 'os,library'
+          severity: 'CRITICAL'

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,11 +32,11 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           exit-code: '0'
           vuln-types: 'os,library'
           severity: 'CRITICAL'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building, pushing, and vulnerability scanning of Docker images for the repository. The workflow is triggered on specific events, such as tag pushes, scheduled runs, or manual dispatches.

### New GitHub Actions Workflow for Docker Automation:

* `.github/workflows/docker-build-and-push.yml`: Added a workflow named `Docker Build and Push` that:
  - Builds and pushes Docker images to the GitHub Container Registry (`ghcr.io`) using `docker/build-push-action@v3`.
  - Logs in to the registry securely using the `docker/login-action@v2` with the `GITHUB_TOKEN`.
  - Scans the built Docker images for vulnerabilities using `aquasecurity/trivy-action@0.29.0`.
  - Is triggered by tag pushes, a scheduled cron job (Monday to Friday at 10 PM UTC), or manual workflow dispatch.