### PR TITLE
fix: 設定を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "ignorePresets": [
     ":prHourlyLimit2"
   ],
-  "timeZone": "Asia/Tokyo",
+  "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": false,
   "branchConcurrentLimit": 0


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` configuration file. The change corrects the casing of the `timeZone` key to `timezone` for consistency with Renovate's expected format.