### PR TITLE
chore: GHAを自動更新する設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,20 @@
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": false,
-  "branchConcurrentLimit": 0
+  "branchConcurrentLimit": 0,
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "groupName": "github-actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeComment": "This PR has been automatically merged by Renovate.",
+      "schedule": ["every saturday at 00:00"]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration file to enable and customize the management of GitHub Actions dependencies. It introduces new rules for automatic merging and scheduling.

Renovate configuration changes:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L11-R26): Added the `enabledManagers` field to include `github-actions` for dependency management.
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L11-R26): Introduced `packageRules` to group and manage `github-actions` dependencies, enabling automatic merging of pull requests with a comment and scheduling merges every Saturday at midnight.