### PR TITLE
chore: 動作確認のために一時的に実行タイミングを調整

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
       "automergeType": "pr",
       "commitMessagePrefix": "chore(deps): ",
       "automergeComment": "This PR has been automatically merged by Renovate.",
-      "schedule": ["every saturday at 00:00"]
+      "schedule": ["every sunday at 16:00"]
     },
     {
       "groupName": "Dockerfile",
@@ -32,7 +32,7 @@
       "automergeType": "pr",
       "matchUpdateTypes": ["minor", "patch"],
       "commitMessagePrefix": "chore(deps): ",
-      "schedule": ["every saturday at 00:00"]
+      "schedule": ["every sunday at 16:00"]
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the dependency update schedule in the `renovate.json` configuration file. The schedule has been changed from Saturdays at midnight to Sundays at 4 PM.