### PR TITLE
chore: Renovateのスケジュールを土曜日に変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
       "automergeType": "pr",
       "commitMessagePrefix": "chore(deps): ",
       "automergeComment": "This PR has been automatically merged by Renovate.",
-      "schedule": ["every sunday at 16:00"]
+      "schedule": ["on satarday"]
     },
     {
       "groupName": "Dockerfile",
@@ -32,7 +32,7 @@
       "automergeType": "pr",
       "matchUpdateTypes": ["minor", "patch"],
       "commitMessagePrefix": "chore(deps): ",
-      "schedule": ["every sunday at 16:00"]
+      "schedule": ["on satarday"]
     }
   ]
 }


### PR DESCRIPTION
This pull request includes minor configuration updates to the `renovate.json` file, specifically modifying the schedule for automated dependency updates.

* **Schedule adjustments:**
  - Changed the update schedule from "every Sunday at 16:00" to "on Saturday" for the general configuration. (`renovate.json`, [renovate.jsonL26-R26](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L26-R26))
  - Changed the update schedule from "every Sunday at 16:00" to "on Saturday" for updates matching "minor" and "patch" types. (`renovate.json`, [renovate.jsonL35-R35](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L35-R35))