### PR TITLE
feat: Thymeleafを使用した新しいHelloページを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/example/test/HelloController.java
+++ b/src/main/java/org/example/test/HelloController.java
@@ -1,0 +1,13 @@
+package org.example.test;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HelloController {
+    @GetMapping("/hello")
+    public String hello() {
+        return "hello";
+    }
+}
+

--- a/src/main/java/org/example/test/TestApplication.java
+++ b/src/main/java/org/example/test/TestApplication.java
@@ -2,7 +2,6 @@ package org.example.test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
@@ -11,11 +10,6 @@ public class TestApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(TestApplication.class, args);
-  }
-
-  @GetMapping("/hello")
-  public String hello() {
-    return "Hello, World!";
   }
 
 }

--- a/src/main/resources/templates/hello.html
+++ b/src/main/resources/templates/hello.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello</title>
+</head>
+<body>
+    <h1>Hello, Thymeleaf!</h1>
+    <p>これはシンプルなHTMLページです。</p>
+</body>
+</html>
+


### PR DESCRIPTION
This pull request introduces a new `HelloController` class to handle `/hello` requests, removes the `/hello` endpoint from `TestApplication`, and adds a Thymeleaf template for rendering the response. These changes improve the separation of concerns by moving the `/hello` endpoint logic into its own controller and enhance the user experience with a dedicated HTML template.

### Controller and Routing Updates:
* Created `HelloController` in `src/main/java/org/example/test/HelloController.java` to handle `/hello` requests using the `@Controller` and `@GetMapping` annotations.
* Removed the `/hello` endpoint from `TestApplication` to delegate routing logic to `HelloController`.

### Template Addition:
* Added a new Thymeleaf template `hello.html` in `src/main/resources/templates/hello.html` to render a simple HTML page for the `/hello` endpoint.

### Code Cleanup:
* Removed unused `@GetMapping` import from `TestApplication.java` after refactoring.